### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,11 +6,11 @@
 # Class (KEYWORD1)
 #######################################
 
-IController	    KEYWORD1
+IController	KEYWORD1
 ILEDController	KEYWORD1
-ILEDIntensity	  KEYWORD1
+ILEDIntensity	KEYWORD1
 IRGBController	KEYWORD1
-IRGBIntensity	  KEYWORD1
+IRGBIntensity	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -19,32 +19,32 @@ IRGBIntensity	  KEYWORD1
 # methods names in common
 
 # IController interface
-reset	        KEYWORD2
+reset	KEYWORD2
 
 # ILEDController interface
-getPin        KEYWORD2
+getPin	KEYWORD2
 
 # ILEDIntensity interface
 getIntensity	KEYWORD2
 setIntensity	KEYWORD2
 
 # IRGBController interface
-getPins   KEYWORD2
-setRGBI   KEYWORD2
+getPins	KEYWORD2
+setRGBI	KEYWORD2
 
 # IRGBIntensity interface
-getRGB	  KEYWORD2
-setRGB	  KEYWORD2
-getRed    KEYWORD2
-setRed    KEYWORD2
-getGreen  KEYWORD2
-setGreen  KEYWORD2
-getBlue   KEYWORD2
-setBlue   KEYWORD2
+getRGB	KEYWORD2
+setRGB	KEYWORD2
+getRed	KEYWORD2
+setRed	KEYWORD2
+getGreen	KEYWORD2
+setGreen	KEYWORD2
+getBlue	KEYWORD2
+setBlue	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-Resolution          LITERAL1
-CUSTOM_RESOLUTION   LITERAL1
+Resolution	LITERAL1
+CUSTOM_RESOLUTION	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords